### PR TITLE
Update ui-carousel-item to transparent background

### DIFF
--- a/ui-carousel-item/ui-carousel-item.component.ts
+++ b/ui-carousel-item/ui-carousel-item.component.ts
@@ -48,7 +48,7 @@ import { UILazyloadDirective } from '../directives/ui-lazy-load.directive';
         .ui-carousel-item{
             height: 100%;
             width: 100%;
-            background: orange;
+            background: transparent;
             position: absolute;    
             overflow: hidden;
         }


### PR DESCRIPTION
The Orange is too jarring on load.  A transparent or less jarring color should be used.  I'm going with transparent here.